### PR TITLE
Enable nested reducer names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,41 @@ export const todos = createReducer(initialState, {
 })
 ```
 
+It is also possible to provide an object with nested reducer names which will be
+flattened by concating them with an underscore.
+
+```js
+import { createReducer } from 'redux-create-reducer';
+import * as ActionTypes from '../constants/ActionTypes';
+
+const initialState = [];
+
+
+export const todos = createReducer(initialState, {
+  [ActionTypes.ADD_TODO]: {
+    PENDING(state, action) {
+      // ...
+    },
+
+    FULFILLED(state, action) {
+      // ...
+    },
+
+    REJECTED(state, action) {
+      // ...
+    }
+  }
+})
+
+/* Same as
+{
+  [ActionTypes.ADD_TODO + '_PENDING']() {},
+  [ActionTypes.ADD_TODO + '_REJECTED']() {},
+  [ActionTypes.ADD_TODO + '_FULFILLED']() {}
+}
+*/
+```
+
 
 
 [npm-image]: https://img.shields.io/npm/v/redux-create-reducer.svg?style=flat-square

--- a/index.js
+++ b/index.js
@@ -5,19 +5,73 @@ try {
   __DEV__ = process.env.NODE_ENV !== 'production';
 } catch (e) {}
 
+var maybeWarn = ! __DEV__ ? function() {} : function() {
+  console.warn(
+    'Reducer contains an \'undefined\' action type. ' +
+    'Have you misspelled a constant?'
+  );
+};
+
+/**
+ * Flatten a nested object of reducer definitions up to the first
+ * level of nesting.
+ *
+ * Example:
+ * ------BEFORE---------+---------AFTER-----------
+ * {                    | {
+ *   Parent: {          |    Parent_Child1() {
+ *     Child1() {       |    },
+ *     },               |
+ *                      |    Parent_Child2() {
+ *     Child2() {       |    },
+ *     },               |
+ *   },                 |    Firstlevel() {
+ *                      |    }
+ *   Firstlevel() {     |
+ *   }                  | }
+ * }                    |
+ *
+ * @param  {object}  reducers  (Nested) reducer definition object
+ * @param  {string*} glue  String to concat names with, optional, default: '_'
+ * @return  {object}  Flattened object
+ */
+var flattenReducers = function flattenReducers(reducers, glue) {
+  glue || ( glue = '_' );
+  var output = {};
+
+  var keys = Object.keys( reducers )
+                    .forEach( function(key) {
+                      var sub = reducers[key];
+
+                      // If it is an object we glue pieces together
+                      if( null !== sub && 'object' === typeof sub ) {
+                        if( sub['undefined'] )
+                          maybeWarn();
+
+                        Object.keys( sub )
+                              .forEach( function(subkey) {
+                                output[ key + glue + subkey ] = sub[subkey];
+                              });
+                      }
+                      else
+                        output[key] = sub;
+
+                    });
+
+  return output;
+};
+
 exports.createReducer = function createReducer(initialState, handlers) {
-  if (__DEV__ && handlers['undefined']) {
-    console.warn(
-      'Reducer contains an \'undefined\' action type. ' +
-      'Have you misspelled a constant?'
-    )
-  }
+  if ( handlers['undefined'] )
+    maybeWarn();
+
+  var flattened = flattenReducers( handlers );
 
   return function reducer(state, action) {
     if (state === undefined) state = initialState;
 
-    if (handlers.hasOwnProperty(action.type)) {
-      return handlers[action.type](state, action);
+    if (flattened.hasOwnProperty(action.type)) {
+      return flattened[action.type](state, action);
     } else {
       return state;
     }

--- a/test.js
+++ b/test.js
@@ -112,7 +112,7 @@ describe('createReducer', function() {
       var reducer = createReducer({}, reducerMap);
       spy.restore();
       expect(spy).toHaveBeenCalled();
-      expect(reducer(undefined, {type: 'undefined'})).toEqual('theproperstate');
+      expect(reducer(undefined, {type: 'YOLO_undefined'})).toEqual('theproperstate');
     });
 
     it('does not warn about undefined action type names if not in development mode', function() {

--- a/test.js
+++ b/test.js
@@ -103,11 +103,13 @@ describe('createReducer', function() {
       var MUFFIN = undefined;
       var reducerMap = {
         YOLO: {
-          [MUFFIN]: function() {
-            return 'theproperstate';
-          }
         }
       };
+
+      reducerMap.YOLO[MUFFIN] = function() {
+        return 'theproperstate';
+      };
+
       var spy = expect.spyOn(console, 'warn')
       var reducer = createReducer({}, reducerMap);
       spy.restore();

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ describe('createReducer', function() {
     expect(reducer(undefined, {type: 'YOLO'})).toEqual('theintialstate');
   });
 
-  it('returns the correct state on the first call with a matche', function() {
+  it('returns the correct state on the first call with a match', function() {
     var reducerMap = {
       YOLO: function() {
         return 'theproperstate';

--- a/test.js
+++ b/test.js
@@ -96,7 +96,45 @@ describe('createReducer', function() {
       };
       var reducer = createReducer({someObj: 1}, reducerMap);
       var state = reducer(undefined, {});
-      expect(reducer(state, {type: 'YOLO_BAR'})).toEqual({someObj: 42});
+      expect(reducer(state, {type: 'YOLO_BEAR'})).toEqual({someObj: 42});
+    });
+
+    it('warns about undefined action type names, but keeps them intact', function() {
+      var MUFFIN = undefined;
+      var reducerMap = {
+        YOLO: {
+          [MUFFIN]: function() {
+            return 'theproperstate';
+          }
+        }
+      };
+      var spy = expect.spyOn(console, 'warn')
+      var reducer = createReducer({}, reducerMap);
+      spy.restore();
+      expect(spy).toHaveBeenCalled();
+      expect(reducer(undefined, {type: 'undefined'})).toEqual('theproperstate');
+    });
+
+    it('does not warn about undefined action type names if not in development mode', function() {
+      var NODE_ENV = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      delete require.cache[require.resolve('./')];
+
+      var createReducer = require('./').createReducer;
+
+      var COOKIE = undefined;
+      var reducerMap = {
+        YOLO: {
+          [COOKIE]: function() {
+            return 'theproperstate';
+          }
+        }
+      };
+      var spy = expect.spyOn(console, 'warn')
+      var reducer = createReducer({}, reducerMap);
+      process.env.NODE_ENV = NODE_ENV;
+      spy.restore();
+      expect(spy).toNotHaveBeenCalled();
     });
 
   });

--- a/test.js
+++ b/test.js
@@ -72,4 +72,33 @@ describe('createReducer', function() {
     expect(spy).toNotHaveBeenCalled()
   });
 
+  describe('flattening', function() {
+
+    it('returns the correct state on the first call with a match', function() {
+      var reducerMap = {
+        YOLO: {
+          SQUIRREL: function() {
+            return 'iamnotafish';
+          }
+        }
+      };
+      var reducer = createReducer('theintialstate', reducerMap);
+      expect(reducer(undefined, {type: 'YOLO_SQUIRREL'})).toEqual('iamnotafish');
+    });
+
+    it('returns a new state if a nested value matched', function() {
+      var reducerMap = {
+        YOLO: {
+          BEAR: function() {
+            return {someObj: 42};
+          }
+        }
+      };
+      var reducer = createReducer({someObj: 1}, reducerMap);
+      var state = reducer(undefined, {});
+      expect(reducer(state, {type: 'YOLO_BAR'})).toEqual({someObj: 42});
+    });
+
+  });
+
 });


### PR DESCRIPTION
This PR adds the ability to define reducers with a nested name structure which will be flattened by concating the names with an underscore.

``` javascript
{
  ACTION: {
    PENDING(state, action) {},
    REJECTED(state, action) {}
}
```

becomes

``` javascript
{
  ACTION_PENDING(state, action) {},
  ACTION_REJECTED(state, action) {}
}
```

PR includes:
- Tests
- Documentation
- Actually implementation
- And a bit of restructuring

Tried to follow your conventions as much as I can.

Background story:
We use (redux-promise-middleware)[https://github.com/pburtchaell/redux-promise-middleware] for actions that do async operations and it fires multiple actions with status prefix (`_PENDING`, `_REJECTED`, `_FULFILLED`). Writing the reducers with this kind of nested structure makes the code easier to read and thus more maintainable for us.
