### PR TITLE
Fix entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "redux-create-reducer",
   "version": "1.1.0",
   "description": "Publishing createReducer from http://rackt.github.io/redux/docs/recipes/ReducingBoilerplate.html",
-  "main": "./lib/index.js",
+  "main": "./index.js",
   "scripts": {
     "test-cov": "node ./node_modules/istanbul/lib/cli.js cover -x test.js node_modules/mocha/bin/_mocha 'test.js' -- --reporter dot",
     "test-travis": "node ./node_modules/istanbul/lib/cli.js cover -x test.js ./node_modules/mocha/bin/_mocha 'test.js' -- -R spec",


### PR DESCRIPTION
The `main` field of `package.json` pointed to a path that did not exist. I'm not sure why other people did not see this. My only guess is that maybe certain build systems (node? webpack?) default to `index.js` if it can't find the `main` file. In my case, I was using React Native and things just blew up.
