### PR TITLE
Bug Fixed: Invalid type for Handlers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { Action, AnyAction, Reducer } from 'redux';
 
 export interface Handlers<S, A extends Action = AnyAction> {
-    [actionType: string]: Reducer<S, A>;
+    [actionType: string]: (state: S, action: A) => S
 }
 
 export declare function createReducer<S, A extends Action = AnyAction>(initialState: S, handlers: Handlers<S, A>): Reducer<S, A>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-create-reducer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Publishing createReducer from http://rackt.github.io/redux/docs/recipes/ReducingBoilerplate.html",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
Type `Reducer` from redux has the following signature `(s: S | undefined, A: AnyAction) => S`, but in our reducer map `s` will never be `undefined` because of initial state. Therefore signature for our reducers in a reducer map should not have union with `undefined` for the first argument.